### PR TITLE
Fix for show Keybind

### DIFF
--- a/buttons.lua
+++ b/buttons.lua
@@ -1107,6 +1107,10 @@ function ConRO:FindKeybinding(id)
 				end
 
 				keybind = GetBindingKey(button);
+
+				if keybind ~= nil then
+					return keybind;
+				end
 			end
 		end
 	end


### PR DESCRIPTION
Early return after find the first keybind.